### PR TITLE
MSVC-friendly likely()...

### DIFF
--- a/rinutils/include/rinutils/likely.h
+++ b/rinutils/include/rinutils/likely.h
@@ -11,5 +11,18 @@
 // and unlikely macros. See: https://lwn.net/Articles/255364/ .
 #pragma once
 
-#define unlikely(expr) __builtin_expect(!!(expr), 0)
-#define likely(expr) __builtin_expect(!!(expr), 1)
+#if !defined(likely)
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__) || (defined(__IBMC__) || defined(__IBMCPP__))
+#if defined(__cplusplus)
+// https://stackoverflow.com/a/43870188/1067003
+#define likely(x)       __builtin_expect(static_cast<bool>((x)),1)
+#define unlikely(x)     __builtin_expect(static_cast<bool>((x)),0)
+#else
+#define likely(x)       __builtin_expect(!!(x),1)
+#define unlikely(x)     __builtin_expect(!!(x),0)
+#endif
+#else
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
+#endif


### PR DESCRIPTION
not saying this is better code, but by making this PR, you can at least consider it. commit message follows:

__builtin_expect is not really portable, and there is 1 major compiler that don't support it: MSVC, 
here is a list of compilers known to support it.. unfortunately i don't think there is a portable way to detect support at compile-time, at least i don't know of any.