### PR TITLE
likely(): Cray C, TCC, DMC, and unknown compilers

### DIFF
--- a/rinutils/include/rinutils/likely.h
+++ b/rinutils/include/rinutils/likely.h
@@ -12,8 +12,9 @@
 #pragma once
 
 #if !defined(likely)
+// compilers known to support it: gnu gcc, intel icc, clang, IBM C, Cray C
 #if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__) ||    \
-    (defined(__IBMC__) || defined(__IBMCPP__))
+    (defined(__IBMC__) || defined(__IBMCPP__)) || defined(_CRAYC)
 #if defined(__cplusplus)
 // https://stackoverflow.com/a/43870188/1067003
 #define likely(x) __builtin_expect(static_cast<bool>((x)), 1)
@@ -23,7 +24,15 @@
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 #else
+// compilers known to _not_ support it: tcc (TinyC), msvc, Digital Mars
+#if defined(__TINYC__) || defined(_MSC_VER) || defined(__DMC__)
 #define likely(x) (x)
 #define unlikely(x) (x)
+#else
+// unknown compiler
+#warning support for __builtin_expect() is unknown on this compiler. please submit a bugreport.
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
 #endif
 #endif


### PR DESCRIPTION
.. i won't blame you if you think this is getting way out of hand and reject it, but here goes:

Cray C Compiler supports __builtin_expect.

TCC (Tiny C Compiler) and DMC (Digital Mars Compiler) and MSVC (Microsoft Visual C) does not.

and finally, issue a warning asking for a bugreport for unknown compilers.