### PR TITLE
cleanup likely() implementation

### DIFF
--- a/rinutils/include/rinutils/likely.h
+++ b/rinutils/include/rinutils/likely.h
@@ -12,9 +12,6 @@
 #pragma once
 
 #if !defined(likely)
-// compilers known to support it: gnu gcc, intel icc, clang, IBM C, Cray C
-#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__) ||    \
-    (defined(__IBMC__) || defined(__IBMCPP__)) || defined(_CRAYC)
 #if defined(__cplusplus)
 // https://stackoverflow.com/a/43870188/1067003
 #define likely(x) __builtin_expect(static_cast<bool>((x)), 1)
@@ -22,17 +19,5 @@
 #else
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
-#endif
-#else
-// compilers known to _not_ support it: tcc (TinyC), msvc, Digital Mars
-#if defined(__TINYC__) || defined(_MSC_VER) || defined(__DMC__)
-#define likely(x) (x)
-#define unlikely(x) (x)
-#else
-// unknown compiler
-#warning support for __builtin_expect() is unknown on this compiler. please submit a bugreport.
-#define likely(x) (x)
-#define unlikely(x) (x)
-#endif
 #endif
 #endif


### PR DESCRIPTION
per the policy described in https://github.com/shlomif/rinutils/commit/8dcbf258e23d74f21fc8d04cc803dcd253f9bea0 , 
a much cleaner implementation of likely() is sensible